### PR TITLE
Update control_loop.h

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/control_loop.h
+++ b/gr-blocks/include/gnuradio/blocks/control_loop.h
@@ -336,9 +336,9 @@ static float tanh_lut_table[256] = {
  */
 static inline float tanhf_lut(float x)
 {
-    if (x > 2)
+    if (x >= 2)
         return 1;
-    else if (x <= -2)
+    else if (x < -2)
         return -1;
     else {
         int index = 128 + 64 * x;


### PR DESCRIPTION
Modified to avoid out-of-bound array access at edges of table. I believe C++ float-to-int behavior is to truncate. Given that, and since index must be 0-255 to stay within array bounds, x must be constrained to [-2.0, 2.0), right?